### PR TITLE
[B] Revise guard for event tracking

### DIFF
--- a/app/assets/javascripts/track-filter-events.js
+++ b/app/assets/javascripts/track-filter-events.js
@@ -8,7 +8,7 @@
  * @param {SubmitEvent} event
  */
 export default function trackFilterEvents(event) {
-  if (!(event?.target instanceof HTMLFormElement) || !_paq?.push) return;
+  if (!(event?.target instanceof HTMLFormElement) || typeof _paq !== "object" || typeof _paq?.push !== "function") return;
 
   const formData = new FormData(event.target);
 


### PR DESCRIPTION
Fixes a ReferenceError appearing in envs where Matomo is not instantiated