### PR TITLE
[C] Conditionally skip editor validations

### DIFF
--- a/app/admin/solutions.rb
+++ b/app/admin/solutions.rb
@@ -40,6 +40,7 @@ ActiveAdmin.register Solution do
     # @return [void]
     def apply_editor_validations!(solution)
       solution.apply_editor_validations = true
+      solution.skip_editor_validations = solution.persisted? && current_user.has_any_admin_access?
     end
 
     # @param [Solution] solution


### PR DESCRIPTION
Restore logic to conditionally skip editor validations, except only for actual Solution records and only when updating a solution.

Creating a new solution will still require all the new validations, and working with a draft under any circumstance will as well.