### PR TITLE
[B] Resolve draft cloning and diffing issues

### DIFF
--- a/app/admin/solution_drafts.rb
+++ b/app/admin/solution_drafts.rb
@@ -84,7 +84,6 @@ ActiveAdmin.register SolutionDraft do
         panel "Pending Changes" do
           para <<~TEXT.html_safe
           The following is a brief overview of the changes in this draft (if any).
-          Fields are presented in alphabetical order.
           TEXT
 
           table_for solution_draft.changed_fields do

--- a/app/assets/stylesheets/entrypoints/active_admin.scss
+++ b/app/assets/stylesheets/entrypoints/active_admin.scss
@@ -33,3 +33,17 @@
   padding: 0;
   text-shadow: unset;
 }
+
+.solution-property--image-preview {
+  max-width: 20vw;
+}
+
+.solution-property--image-diff {
+  max-width: 10vw;
+}
+
+.solution-property--diff-wrapper {
+  display: block;
+  max-width: 30vw;
+  overflow-x: scroll;
+}

--- a/app/models/solution_draft.rb
+++ b/app/models/solution_draft.rb
@@ -83,7 +83,9 @@ class SolutionDraft < ApplicationRecord
   end
 
   def should_check?
-    SolutionProperty.to_clone.any? do |attr|
+    return true if saved_change_to_attribute? :free_inputs
+
+    SolutionProperty.to_clone.without(SolutionProperty.free_input_names).any? do |attr|
       case attr
       when *SolutionProperty.attachment_values
         saved_change_to_attribute? :"#{attr}_data"

--- a/app/models/solution_property.rb
+++ b/app/models/solution_property.rb
@@ -601,6 +601,10 @@ class SolutionProperty < Support::FrozenRecordHelpers::AbstractRecord
       each_free_input.map(&:free_input_name)
     end
 
+    memoize def store_model_list_names
+      store_model_lists.pluck(:name)
+    end
+
     # @return [Hash]
     def generate_locale
       mapping = in_use.order(name: :asc).each_with_object({}) do |prop, h|
@@ -645,16 +649,7 @@ class SolutionProperty < Support::FrozenRecordHelpers::AbstractRecord
         a.concat Implementation.pluck(:name, :enum).flatten
         a.concat has_one_associations
         a.concat has_many_associations
-      end.then { symbolize_list _1 }
-    end
-
-    memoize def to_clone_draft
-      [].tap do |a|
-        a.concat standard_values
-        a.concat free_input_names
-        a.concat Implementation.pluck(:name, :enum).flatten
-        a.concat has_one_associations
-        a.concat has_many_associations
+        a.concat store_model_list_names
       end.then { symbolize_list _1 }
     end
 

--- a/app/services/admin/enhanced_form_builder.rb
+++ b/app/services/admin/enhanced_form_builder.rb
@@ -35,6 +35,8 @@ module Admin
         store_model(attr, heading: false, name: "Details") do |impf|
           yield impf if block_given?
 
+          impf.input :statement, as: :hidden
+
           if obj_type.has_many_links?
             heading = obj_type.human_attribute_name(:links)
 

--- a/app/services/controlled_vocabularies/options_fetcher.rb
+++ b/app/services/controlled_vocabularies/options_fetcher.rb
@@ -87,7 +87,7 @@ module ControlledVocabularies
             "data-iso-code" => c.iso_code
           )
 
-          ["#{c.name} (#{c.iso_code})", c.id, props]
+          ["#{c.name} (#{c.iso_code})", c.iso_code, props]
         end
       end
 

--- a/app/services/implementations/abstract_implementation.rb
+++ b/app/services/implementations/abstract_implementation.rb
@@ -181,7 +181,7 @@ module Implementations
 
       # @return [Array]
       def strong_params
-        attribute_names.without("link", "links", "statement").map(&:to_sym).tap do |arr|
+        attribute_names.without("link", "links").map(&:to_sym).tap do |arr|
           case link_mode
           in :many
             arr << { links_attributes: %i[url label] }

--- a/app/services/solution_drafts/changed_field.rb
+++ b/app/services/solution_drafts/changed_field.rb
@@ -42,9 +42,21 @@ module SolutionDrafts
 
       case field_kind
       in :attachment
-        context.image_tag value.url
+        context.image_tag value.url, class: "solution-property--image-diff"
+      in :blurb
+        context.content_tag(:div, class: "solution-property--diff-wrapper") do
+          value.html_safe
+        end
+      in :boolean
+        value
+      in :multi_option
+        value
+      in :single_option
+        value
       else
-        return value
+        context.content_tag(:div, class: "solution-property--diff-wrapper") do
+          value
+        end
       end
     end
   end

--- a/app/services/solution_properties/admin/property_wrapper.rb
+++ b/app/services/solution_properties/admin/property_wrapper.rb
@@ -224,7 +224,7 @@ module SolutionProperties
 
         case kind
         when :attachment
-          view_context.image_tag(value.url) if value.present?
+          view_context.image_tag(value.url, class: "solution-property--image-preview") if value.present?
         when :blurb, :other_option, :store_model_input
           view_context.simple_format(value) if value.present?
         when :contact

--- a/app/services/solutions/attribute_comparator.rb
+++ b/app/services/solutions/attribute_comparator.rb
@@ -41,6 +41,8 @@ module Solutions
       @changes = {}.with_indifferent_access
       @source_kind = source.solution_kind
       @target_kind = target.solution_kind
+      @key = @prop = @vocab = nil
+      @vocab = nil
 
       super
     end
@@ -54,23 +56,64 @@ module Solutions
 
     wrapped_hook! def compare
       SolutionProperty.to_clone.each do |key|
+        @key = key
+        @prop = SolutionProperty.find(key.to_s)
+        @vocab = @prop.vocab
+
         source_value = source_attributes[key]
         target_value = target_attributes[key]
 
-        changes[key] = [source_value, target_value] unless values_match?(key, source_value, target_value)
+        changes[key] = [source_value, target_value] unless values_match?(source_value, target_value)
+      ensure
+        @key = @prop = @vocab = nil
       end
 
       super
     end
 
-    # @return [Boolean] true if value is the same
-    def values_match?(key, source_value, target_value)
-      case key.to_s
-      when *SolutionProperty.attachment_values
-        source_value&.sha256 == target_value&.sha256
+    def find_term(value)
+      case value
+      when ControlledVocabularyRecord
+        find_term value.term
       else
-        source_value == target_value
+        @vocab.find_term(value).value_or(nil)
       end
+    end
+
+    def compare_nested(value)
+      case value
+      when Array
+        value.map { compare_nested _1 }
+      when Hash
+        value.transform_values { compare_nested _1 }
+      when StoreModel::Model
+        compare_nested value.as_json
+      else
+        value.presence
+      end
+    end
+
+    def to_compare(raw_value)
+      case @prop.kind
+      when :attachment
+        raw_value&.sha256
+      when :boolean
+        raw_value
+      when :multi_option
+        Array(raw_value).map { find_term(_1) }.compact.sort
+      when :single_option
+        find_term(raw_value)
+      else
+        compare_nested raw_value
+      end
+    end
+
+    # @return [Boolean] true if value is the same
+    def values_match?(source_value, target_value)
+      compare_source = to_compare source_value
+      compare_target = to_compare target_value
+
+      compare_source == compare_target
     end
   end
 end

--- a/lib/frozen_record/solution_property_kinds.yml
+++ b/lib/frozen_record/solution_property_kinds.yml
@@ -5,7 +5,7 @@
   diff_klass_name: AttachmentDiff
   standard: false
 - kind: blurb
-  diffable: false
+  diffable: true
   diff_klass_name: TextDiff
   input_kind: :text
   input_html:


### PR DESCRIPTION
This commit makes several improvements and fixes a few bugs found with diffing draft and solution attributes.

* Ensure store model lists are cloned properly
* treat empty string and nil as equal for the purposes of diffing
* simplify implementations and store model lists for comparison
* compare controlled vocab terms case-insensitively for dealing with legacy data,
* allow blurbs to be displayed in diffs
* Include implementation statements as hidden attribute in forms in order to avoid unnecessarily showing implementations as changed when they really haven't
* Apply some max-width constraints on images in admin section