### PR TITLE
Update header and footer to new IOI website design

### DIFF
--- a/app/components/footer_component/footer_component.html.erb
+++ b/app/components/footer_component/footer_component.html.erb
@@ -23,47 +23,302 @@
       </div>
     </div>
   </aside>
-  <footer class="bg-black l-container l-container--narrow" data-controller="footer-component--footer-component">
-    <div class="l-container__inner footer-wrap">
-      <div class="footer-data">
-        <a href="https://investinopen.org" class="footer-logo print:hidden">
-          <%= image_tag "logos/ioi-logo-light.svg", alt: "Invest in Open Infrastructure" %>
+<!-- Static IOI footer for Infra Finder -->
+<style>
+  .ioi-static-footer,
+  .ioi-static-footer * {
+    box-sizing: border-box;
+  }
+
+  .ioi-static-footer {
+    --ioi-black: #000;
+    --ioi-white: #fff;
+    --ioi-yellow: #ffdc16;
+    background: var(--ioi-black);
+    color: var(--ioi-white);
+    font-family: Inter, Arial, Helvetica, sans-serif;
+    padding: clamp(3.5rem, 7vw, 7rem) 0 clamp(2rem, 4vw, 3rem);
+  }
+
+  .ioi-static-footer__inner {
+    width: min(100% - 4rem, 100rem);
+    margin: 0 auto;
+  }
+
+  .ioi-static-footer__top {
+    display: grid;
+    grid-template-columns: minmax(16rem, 0.9fr) minmax(34rem, 1.7fr);
+    gap: clamp(3rem, 8vw, 9rem);
+    align-items: start;
+  }
+
+  .ioi-static-footer__brand {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+  }
+
+  .ioi-static-footer__logo {
+    display: inline-flex;
+    width: clamp(13rem, 18vw, 17.5rem);
+    max-width: 100%;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .ioi-static-footer__logo img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .ioi-static-footer__description {
+    max-width: 30rem;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.78);
+    font-size: clamp(1.05rem, 1.35vw, 1.3rem);
+    font-weight: 400;
+    line-height: 1.35;
+  }
+
+  .ioi-static-footer__social {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .ioi-static-footer__social a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.35rem;
+    height: 3.35rem;
+    border-radius: 999px;
+    background: var(--ioi-yellow);
+    color: var(--ioi-black);
+    text-decoration: none;
+    transition: background 160ms ease, transform 160ms ease;
+  }
+
+  .ioi-static-footer__social a:hover,
+  .ioi-static-footer__social a:focus-visible {
+    background: var(--ioi-white);
+    transform: translateY(-2px);
+  }
+
+  .ioi-static-footer__social svg {
+    display: block;
+    width: 1.25rem;
+    height: 1.25rem;
+    fill: currentColor;
+  }
+
+  .ioi-static-footer__social .ioi-static-footer__email-icon {
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .ioi-static-footer__nav {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: clamp(2rem, 5vw, 5rem);
+  }
+
+  .ioi-static-footer__heading {
+    margin: 0 0 1.55rem;
+    color: var(--ioi-yellow);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .ioi-static-footer__links,
+  .ioi-static-footer__legal-links {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .ioi-static-footer__links li + li {
+    margin-top: 0.82rem;
+  }
+
+  .ioi-static-footer__links a,
+  .ioi-static-footer__legal-links a {
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.25;
+    text-decoration: none;
+    transition: color 160ms ease;
+  }
+
+  .ioi-static-footer__links a:hover,
+  .ioi-static-footer__links a:focus-visible,
+  .ioi-static-footer__legal-links a:hover,
+  .ioi-static-footer__legal-links a:focus-visible {
+    color: var(--ioi-yellow);
+    text-decoration: underline;
+    text-decoration-thickness: 0.14em;
+    text-underline-offset: 0.2em;
+  }
+
+  .ioi-static-footer__bottom {
+    display: flex;
+    gap: 2rem;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: clamp(4rem, 8vw, 7rem);
+    padding-top: 2.4rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.22);
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .ioi-static-footer__copyright {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 400;
+    line-height: 1.4;
+  }
+
+  .ioi-static-footer__legal-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 1rem 2rem;
+  }
+
+  .ioi-static-footer__legal-links a {
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 980px) {
+    .ioi-static-footer__top {
+      grid-template-columns: 1fr;
+    }
+
+    .ioi-static-footer__nav {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 640px) {
+    .ioi-static-footer__inner {
+      width: min(100% - 2rem, 118rem);
+    }
+
+    .ioi-static-footer__nav {
+      grid-template-columns: 1fr;
+    }
+
+    .ioi-static-footer__bottom {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .ioi-static-footer__legal-links {
+      justify-content: flex-start;
+    }
+  }
+</style>
+
+<footer class="ioi-static-footer" role="contentinfo" data-controller="footer-component--footer-component">
+  <div class="ioi-static-footer__inner">
+    <div class="ioi-static-footer__top">
+      <div class="ioi-static-footer__brand">
+        <a class="ioi-static-footer__logo" href="https://investinopen.org/" aria-label="Invest in Open Infrastructure">
+          <img src="https://investinopen.org/assets/redesign/ioi-logo-light.svg" alt="Invest in Open Infrastructure">
         </a>
-        <a href="https://investinopen.org" class="footer-logo hidden print:block">
-          <%= image_tag "logos/ioi-logo-dark.svg", alt: "Invest in Open Infrastructure" %>
-        </a>
-        <div class="footer-copyright">
-          © Invest in Open Infrastructure, subject to a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-        </div>
-        <ul id="terms" class="print:hidden">
-          <li><a href="https://investinopen.org/ioi-privacy-policy">Privacy Policy</a></li>
-          <li><a href="https://investinopen.org/terms-and-conditions/">Terms &amp; Conditions</a></li>
+
+        <p class="ioi-static-footer__description">Helping you invest in the open technology that research relies on.</p>
+
+        <ul class="ioi-static-footer__social" aria-label="Social links">
+          <li>
+            <a href="https://www.linkedin.com/company/invest-in-open" aria-label="LinkedIn" target="_blank" rel="noopener">
+              <svg aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"></path>
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="https://indieweb.social/@investinopen" aria-label="Mastodon" target="_blank" rel="noopener me">
+              <svg aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M23.193 7.879c0-5.206-3.411-6.732-3.411-6.732C18.062.357 15.108.025 12.041 0h-.076c-3.068.025-6.02.357-7.74 1.147 0 0-3.411 1.526-3.411 6.732 0 1.192-.023 2.618.015 4.129.124 5.092.934 10.109 5.641 11.355 2.17.574 4.034.695 5.535.612 2.722-.15 4.25-.972 4.25-.972l-.09-1.975s-1.945.613-4.129.539c-2.165-.074-4.449-.233-4.799-2.891a5.499 5.499 0 0 1-.048-.745s2.125.52 4.817.643c1.646.075 3.19-.097 4.758-.283 3.007-.359 5.625-2.212 5.954-3.905.517-2.665.475-6.507.475-6.507zm-4.024 6.709h-2.497V8.469c0-1.29-.543-1.944-1.628-1.944-1.2 0-1.802.776-1.802 2.312v3.349h-2.483v-3.35c0-1.536-.602-2.312-1.802-2.312-1.085 0-1.628.655-1.628 1.944v6.119H4.832V8.284c0-1.289.328-2.313.987-3.07.68-.758 1.569-1.146 2.674-1.146 1.278 0 2.246.491 2.886 1.474L12 6.585l.622-1.043c.64-.983 1.608-1.474 2.886-1.474 1.104 0 1.994.388 2.674 1.146.658.757.986 1.781.986 3.07v6.304z"></path>
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="https://bsky.app/profile/investinopen.bsky.social" aria-label="Bluesky" target="_blank" rel="noopener">
+              <svg aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M6.08 4.06c2.39 1.8 4.95 5.44 5.92 7.4.97-1.96 3.53-5.6 5.92-7.4 1.72-1.3 4.5-2.3 4.5.9 0 .64-.37 5.37-.59 6.13-.76 2.57-3.53 3.23-6 2.83 4.31.73 5.41 3.15 3.04 5.57-4.5 4.58-6.47-1.15-6.97-2.62-.09-.27-.14-.4-.14-.29 0-.11-.05.02-.14.29-.5 1.47-2.47 7.2-6.97 2.62-2.37-2.42-1.27-4.84 3.04-5.57-2.47.4-5.24-.26-6-2.83-.22-.76-.59-5.49-.59-6.13 0-3.2 2.78-2.2 4.5-.9Z"></path>
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="mailto:contact@investinopen.org" aria-label="Email IOI">
+              <svg class="ioi-static-footer__email-icon" aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M4.75 6.75h14.5v10.5H4.75z"></path>
+                <path d="m5.25 7.25 6.75 5.25 6.75-5.25"></path>
+              </svg>
+            </a>
+          </li>
         </ul>
       </div>
-      <div class="footer-nav">
-        <h3>Navigation</h3>
-        <div class="footer-nav-column">
-          <ul>
+
+      <nav class="ioi-static-footer__nav" aria-label="Footer navigation">
+        <section aria-labelledby="ioi-static-footer-about">
+          <h2 class="ioi-static-footer__heading" id="ioi-static-footer-about">About IOI</h2>
+          <ul class="ioi-static-footer__links">
+            <li><a href="https://investinopen.org/about/">Overview</a></li>
+            <li><a href="https://investinopen.org/about/team/">Meet the IOI Team</a></li>
+            <li><a href="https://investinopen.org/about/governance/">Our Governance</a></li>
             <li><a href="https://investinopen.org/about/funding/">How We're Funded</a></li>
-            <li><a href="https://investinopen.org/about/">About IOI</a></li>
-            <li><a href="https://investinopen.org/code-of-conduct/">Code of Conduct</a></li>
-            <li><a href="https://investinopen.org/contact/">Contact Us</a></li>
-            <li><a href="https://investinopen.org/about/team/">Who We Are</a></li>
-            <li><a href="https://investinopen.org/blog/">Blog</a></li>
-            <li><a href="https://investinopen.org/jobs/">Work With Us</a></li>
-            <li><a href="https://investinopen.org/tag/resources/">Resources</a></li>
-            <li><a href="https://investinopen.org/tag/events/">Events</a></li>
+            <li><a href="https://investinopen.org/about/strategic-plans/">Strategic Plan</a></li>
+            <li><a href="https://investinopen.org/about/our-impact/">Our Impact</a></li>
+            <li><a href="https://investinopen.org/about/faq/">FAQ</a></li>
+            <li><a href="https://investinopen.org/contact-us/">Get In Touch</a></li>
           </ul>
-        </div>
-      </div>
-      <div class="footer-social">
-        <h3>We are on social media</h3>
-        <ul>
-          <li><a href="https://www.linkedin.com/company/invest-in-open" aria-label="link Linkedin" class="arrow">LinkedIn</a></li>
-          <li><a href="https://indieweb.social/@investinopen" aria-label="link Mastodon" class="arrow">Mastodon</a></li>
-          <li><a href="https://bsky.app/profile/investinopen.bsky.social" aria-label="link Bluesky" class="arrow">Bluesky</a></li>
-        </ul>
-      </div>
+        </section>
+
+        <section aria-labelledby="ioi-static-footer-approach">
+          <h2 class="ioi-static-footer__heading" id="ioi-static-footer-approach">IOI's Approach</h2>
+          <ul class="ioi-static-footer__links">
+            <li><a href="https://investinopen.org/our-approach/">Overview</a></li>
+            <li><a href="https://investinopen.org/our-approach/strategic-consulting/">Consultation Services</a></li>
+            <li><a href="https://investinopen.org/our-approach/coordinated-funding/">Coordinated Funding</a></li>
+          </ul>
+        </section>
+
+        <section aria-labelledby="ioi-static-footer-work">
+          <h2 class="ioi-static-footer__heading" id="ioi-static-footer-work">IOI's Work</h2>
+          <ul class="ioi-static-footer__links">
+            <li><a href="https://investinopen.org/our-work/">Overview</a></li>
+            <li><a href="https://investinopen.org/blog/">News &amp; Updates</a></li>
+            <li><a href="https://investinopen.org/state-of-open-infrastructure-2025/">State of Open Infrastructure</a></li>
+            <li><a href="https://infrafinder.investinopen.org/">Infra Finder</a></li>
+          </ul>
+        </section>
+      </nav>
     </div>
-  </footer>
+
+    <div class="ioi-static-footer__bottom">
+      <p class="ioi-static-footer__copyright">&copy; 2026 Invest in Open Infrastructure. Licensed under CC BY 4.0.</p>
+      <ul class="ioi-static-footer__legal-links">
+        <li><a href="https://investinopen.org/code-of-conduct/">Code of Conduct</a></li>
+        <li><a href="https://investinopen.org/privacy-policy/">Privacy Policy</a></li>
+        <li><a href="https://investinopen.org/terms-and-conditions/">Terms &amp; Conditions</a></li>
+        <li><a href="https://investinopen.org/contact-us/">Contact Us</a></li>
+      </ul>
+    </div>
+  </div>
+</footer>
 <% end %>

--- a/app/components/header_component/header_component.html.erb
+++ b/app/components/header_component/header_component.html.erb
@@ -1,86 +1,531 @@
 <%= turbo_frame_tag "site-header", target: "_top" do %>
-<header class="header-section l-container">
-  <div class="l-container__inner header-nav">
-    <nav class="header-nav" id="primary-nav">
-      <a href="https://investinopen.org" id="home-link">
-        <%= image_tag "logos/ioi-logo-dark.svg", alt: "Invest in Open Infrastructure" %>
-      </a>
-      <input id="toggle" class="header-checkbox" type="checkbox">
-      <label class="header-toggle" for="toggle">
-        <span>
-          <span class="bar"></span>
-          <span class="bar"></span>
-          <span class="bar"></span>
-        </span>
-      </label>
-      <ul class="header-nav-list">
-        <li class="header-nav-item">
-          <span class="spacer">About IOI</span>
-          <a href="https://investinopen.org/about">About IOI</a>
-          <ul>
-            <li class="np-about">
-              <span class="spacer">About Us</span>
-              <a href="https://investinopen.org/about">About Us</a>
-            </li>
-            <li class="np-team">
-              <span class="spacer">Our Team</span>
-              <a href="https://investinopen.org/about/team">Our Team</a>
-            </li>
-            <li class="np-governance">
-              <span class="spacer">Our Governance</span>
-              <a href="https://investinopen.org/about/governance">Our Governance</a>
-            </li>
-            <li class="np-funding">
-              <span class="spacer">How We're Funded</span>
-              <a href="https://investinopen.org/about/funding">How We're Funded</a>
-            </li>
-            <li class="np-how-we-work">
-              <span class="spacer">How We Work</span>
-              <a href="https://investinopen.org/about/how-we-work">How We Work</a>
-            </li>
-            <li class="np-strategic-plan-2021-2024">
-              <span class="spacer">Strategic Plan</span>
-              <a href="https://investinopen.org/about/strategic-plan/2024-2027">Strategic Plan</a>
-            </li>
-          </ul>
-        </li>
-        <li class="header-nav-item">
-          <span class="spacer">What We Do</span>
-          <a class="cursor-arrow">What We Do</a>
-          <ul>
-            <li class="np-funding-pilots">
-                <span class="spacer">Funding Pilots</span>
-                <a href="https://investinopen.org/funding-pilots">Funding Pilots</a>
-            </li>
-            <li class="np-strategic-support">
-                <span class="spacer">Strategic Support</span>
-                <a href="https://investinopen.org/strategic-support">Strategic Support</a>
-            </li>
-            <li class="np-data-room">
-                <span class="spacer">Data Room</span>
-                <a href="https://investinopen.org/data-room">Data Room</a>
-            </li>
-          </ul>
-        </li>
-        <li class="header-nav-item">
-          <span class="spacer">Our Impact</span>
-          <a href="https://investinopen.org/our-impact">Our Impact</a>
-        </li>
-        <li class="header-nav-item">
-          <span class="spacer"><%= t(".finder_link") %></span>
-          <%= nav_link "Infra Finder", solutions_path, active: :exclusive %>
-        </li>
-        <li class="header-nav-item">
-          <span class="spacer">News &amp; Updates</span>
-          <a href="https://investinopen.org/blog">News &amp; Updates</a>
+<!-- Static IOI header for Infra Finder -->
+<style>
+  .ioi-static-header,
+  .ioi-static-header * {
+    box-sizing: border-box;
+  }
 
+  .ioi-static-header {
+    --ioi-black: #000;
+    --ioi-white: #fff;
+    --ioi-yellow: #ffdc16;
+    --ioi-green: #83fed1;
+    --ioi-charcoal: #202020;
+    --ioi-nav-height: 5.4rem;
+    width: 100%;
+    background: var(--ioi-black);
+    color: var(--ioi-white);
+    font-family: Inter, Arial, Helvetica, sans-serif;
+  }
+
+  .ioi-static-header__inner {
+    display: grid;
+    grid-template-columns: minmax(10.5rem, 13.5rem) minmax(0, 1fr) auto;
+    gap: clamp(1rem, 2vw, 2rem);
+    align-items: center;
+    width: min(100% - 4rem, 100rem);
+    min-height: var(--ioi-nav-height);
+    margin: 0 auto;
+  }
+
+  .ioi-static-header__logo {
+    display: inline-flex;
+    width: clamp(10.5rem, 15vw, 13.5rem);
+    max-width: 100%;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .ioi-static-header__logo img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .ioi-static-header__nav {
+    justify-self: center;
+  }
+
+  .ioi-static-header__nav-list,
+  .ioi-static-header__actions {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .ioi-static-header__nav-list {
+    gap: clamp(0.25rem, 1.1vw, 1.25rem);
+  }
+
+  .ioi-static-header__nav-item {
+    position: relative;
+  }
+
+  .ioi-static-header__checkbox,
+  .ioi-static-header__toggle,
+  .ioi-static-header__submenu-checkbox,
+  .ioi-static-header__submenu-toggle {
+    display: none;
+  }
+
+  .ioi-static-header__actions {
+    gap: 1rem;
+  }
+
+  .ioi-static-header a {
+    color: inherit;
+  }
+
+  .ioi-static-header__nav-link {
+    display: inline-flex;
+    gap: 0;
+    align-items: center;
+    height: var(--ioi-nav-height);
+    padding: 0 1.25rem;
+    color: var(--ioi-white);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color 160ms ease;
+  }
+
+  .ioi-static-header__submenu {
+    position: absolute;
+    top: calc(var(--ioi-nav-height) - 1.25rem);
+    left: 0;
+    z-index: 10;
+    min-width: 18rem;
+    margin: 0;
+    padding: 0.75rem 0;
+    border-radius: 0.75rem;
+    background: var(--ioi-white);
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.2);
+    list-style: none;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease;
+  }
+
+  .ioi-static-header__nav-item:hover .ioi-static-header__submenu,
+  .ioi-static-header__nav-item:focus-within .ioi-static-header__submenu {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .ioi-static-header__submenu a {
+    display: flex;
+    width: 100%;
+    min-height: 2.65rem;
+    align-items: center;
+    padding: 0.3rem 1.75rem;
+    color: var(--ioi-black);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.2;
+    text-decoration: none;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 3px;
+    text-underline-offset: 0.35rem;
+    white-space: nowrap;
+    transition: color 120ms ease, text-decoration-color 120ms ease;
+  }
+
+  .ioi-static-header__submenu a:hover,
+  .ioi-static-header__submenu a:focus-visible {
+    color: var(--ioi-black);
+    text-decoration-line: underline;
+    text-decoration-color: var(--ioi-yellow);
+  }
+
+  .ioi-static-header__nav-link:hover,
+  .ioi-static-header__nav-link:focus-visible {
+    color: var(--ioi-yellow);
+    text-decoration: none;
+  }
+
+  .ioi-static-header__caret {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    margin: -0.25rem 0 0 0.65rem;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: rotate(45deg);
+    transition: transform 150ms ease, margin 150ms ease;
+  }
+
+  .ioi-static-header__nav-item:hover .ioi-static-header__caret,
+  .ioi-static-header__nav-item:focus-within .ioi-static-header__caret {
+    margin-top: 0.25rem;
+    transform: rotate(225deg);
+  }
+
+  .ioi-static-header__search,
+  .ioi-static-header__contact {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+  }
+
+  .ioi-static-header__search {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 999px;
+    background: var(--ioi-charcoal);
+    color: var(--ioi-white);
+    transition: background 160ms ease, color 160ms ease;
+  }
+
+  .ioi-static-header__search svg {
+    display: block;
+    width: 1.35rem;
+    height: 1.35rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 3;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .ioi-static-header__search:hover,
+  .ioi-static-header__search:focus-visible {
+    background: var(--ioi-yellow);
+    color: var(--ioi-black);
+  }
+
+  .ioi-static-header__contact {
+    min-height: 3rem;
+    padding: 0 1.45rem;
+    border-radius: 999px;
+    background: var(--ioi-yellow);
+    color: var(--ioi-black);
+    font-size: 1rem;
+    font-weight: 800;
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background 160ms ease, color 160ms ease;
+  }
+
+  .ioi-static-header__contact:hover,
+  .ioi-static-header__contact:focus-visible {
+    background: var(--ioi-green);
+    color: var(--ioi-black);
+    text-decoration: none;
+  }
+
+  @media (max-width: 1180px) {
+    .ioi-static-header__inner {
+      width: min(100% - 3rem, 100rem);
+    }
+
+    .ioi-static-header__nav-link {
+      padding: 0 0.85rem;
+    }
+
+    .ioi-static-header__actions {
+      gap: 0.75rem;
+    }
+  }
+
+  @media (max-width: 980px) {
+    .ioi-static-header__inner {
+      position: relative;
+      grid-template-columns: 1fr auto;
+      min-height: auto;
+      padding: 1rem 0;
+    }
+
+    .ioi-static-header__toggle {
+      position: relative;
+      z-index: 20;
+      display: block;
+      width: 52px;
+      height: 46px;
+      margin: 0;
+      padding: 0 8px 2px;
+      border: 1px solid var(--ioi-white);
+      border-radius: 0.75rem;
+      background: var(--ioi-black);
+      box-sizing: border-box;
+      cursor: pointer;
+    }
+
+    .ioi-static-header__toggle > span {
+      position: relative;
+      top: 50%;
+      display: block;
+      width: 100%;
+    }
+
+    .ioi-static-header__toggle-bar {
+      position: absolute;
+      display: block;
+      width: 100%;
+      height: 3px;
+      background: var(--ioi-white);
+      transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1), top 0.3s cubic-bezier(0.645, 0.045, 0.355, 1) 0.2s;
+    }
+
+    .ioi-static-header__toggle-bar:nth-child(1) {
+      top: -10px;
+    }
+
+    .ioi-static-header__toggle-bar:nth-child(3) {
+      top: 10px;
+    }
+
+    .ioi-static-header__checkbox:checked ~ .ioi-static-header__toggle .ioi-static-header__toggle-bar {
+      top: 0;
+      transition: transform 0.3s cubic-bezier(0.645, 0.045, 0.355, 1) 0.3s, top 0.3s cubic-bezier(0.645, 0.045, 0.355, 1);
+    }
+
+    .ioi-static-header__checkbox:checked ~ .ioi-static-header__toggle .ioi-static-header__toggle-bar:nth-child(1),
+    .ioi-static-header__checkbox:checked ~ .ioi-static-header__toggle .ioi-static-header__toggle-bar:nth-child(2) {
+      transform: rotate(45deg);
+    }
+
+    .ioi-static-header__checkbox:checked ~ .ioi-static-header__toggle .ioi-static-header__toggle-bar:nth-child(3) {
+      transform: rotate(-45deg);
+    }
+
+    .ioi-static-header__nav {
+      position: absolute;
+      top: calc(50% + 23px + 0.5rem);
+      right: 0;
+      grid-column: 1 / -1;
+      justify-self: start;
+      order: 3;
+      z-index: 15;
+      display: none;
+      width: min(22rem, calc(100vw - 2rem));
+      max-height: calc(100vh - (50% + 23px + 0.5rem));
+      padding: 0.85rem 0;
+      border: 1px solid var(--ioi-white);
+      border-radius: 0.75rem;
+      background: var(--ioi-black);
+      box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.28);
+      overflow: auto;
+    }
+
+    .ioi-static-header__checkbox:checked ~ .ioi-static-header__nav {
+      display: block;
+    }
+
+    .ioi-static-header__nav-list {
+      display: block;
+    }
+
+    .ioi-static-header__nav-item {
+      display: block;
+      padding: 0;
+    }
+
+    .ioi-static-header__nav-item--has-submenu {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 3rem;
+    }
+
+    .ioi-static-header__nav-link {
+      grid-column: 1;
+      grid-row: 1;
+      height: auto;
+      min-height: 2.75rem;
+      padding: 0.7rem 1.1rem;
+      color: var(--ioi-white);
+      text-align: left;
+      white-space: normal;
+    }
+
+    .ioi-static-header__nav-link:hover,
+    .ioi-static-header__nav-link:focus-visible {
+      color: var(--ioi-yellow);
+    }
+
+    .ioi-static-header__caret {
+      display: none;
+    }
+
+    .ioi-static-header__submenu-toggle {
+      grid-column: 2;
+      grid-row: 1;
+      display: flex;
+      width: 100%;
+      min-height: 2.75rem;
+      align-items: center;
+      justify-content: center;
+      border: 0;
+      background: transparent;
+      color: var(--ioi-white);
+      cursor: pointer;
+      transition: color 150ms ease;
+    }
+
+    .ioi-static-header__submenu-toggle::after {
+      content: "";
+      width: 0.55rem;
+      height: 0.55rem;
+      margin-top: -0.25rem;
+      border-right: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(45deg);
+      transform-origin: center;
+      transition: margin 150ms ease, transform 150ms ease;
+    }
+
+    .ioi-static-header__submenu-checkbox:checked + .ioi-static-header__submenu-toggle::after {
+      margin-top: 0.25rem;
+      transform: rotate(225deg);
+    }
+
+    .ioi-static-header__submenu-toggle:hover,
+    .ioi-static-header__submenu-toggle:focus-visible {
+      color: var(--ioi-yellow);
+    }
+
+    .ioi-static-header__submenu {
+      position: static;
+      display: none;
+      grid-column: 1 / -1;
+      min-width: 0;
+      margin: 0.1rem 0 0.45rem;
+      padding: 0.25rem 0;
+      border-radius: 0;
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: none;
+      opacity: 1;
+      pointer-events: auto;
+      transform: none;
+    }
+
+    .ioi-static-header__submenu-checkbox:checked ~ .ioi-static-header__submenu {
+      display: block;
+    }
+
+    .ioi-static-header__submenu a {
+      min-height: 2.35rem;
+      padding: 0.55rem 1.1rem 0.55rem 1.85rem;
+      color: rgba(255, 255, 255, 0.82);
+      font-size: 0.95rem;
+      text-decoration: none;
+    }
+
+    .ioi-static-header__submenu a:hover,
+    .ioi-static-header__submenu a:focus-visible {
+      color: var(--ioi-yellow);
+      text-decoration: none;
+    }
+
+    .ioi-static-header__actions {
+      display: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .ioi-static-header__inner {
+      width: min(100% - 2rem, 100rem);
+      gap: 0.85rem 1rem;
+    }
+
+    .ioi-static-header__logo {
+      width: 11.5rem;
+    }
+
+    .ioi-static-header__nav-link {
+      min-height: 2.75rem;
+      font-size: 0.95rem;
+    }
+
+    .ioi-static-header__submenu a {
+      font-size: 0.86rem;
+      line-height: 1.25;
+      white-space: normal;
+    }
+  }
+
+  @media (max-width: 460px) {
+    .ioi-static-header__inner {
+      grid-template-columns: 1fr auto;
+    }
+  }
+</style>
+
+<header class="ioi-static-header" role="banner">
+  <div class="ioi-static-header__inner">
+    <a class="ioi-static-header__logo" href="https://investinopen.org/" aria-label="Invest in Open Infrastructure">
+      <img src="https://investinopen.org/assets/redesign/ioi-logo-light.svg" alt="Invest in Open Infrastructure">
+    </a>
+
+    <input id="ioi-static-header-toggle" class="ioi-static-header__checkbox" type="checkbox" aria-label="Toggle navigation">
+    <label class="ioi-static-header__toggle" for="ioi-static-header-toggle" tabindex="0" aria-label="Toggle navigation">
+      <span>
+        <span class="ioi-static-header__toggle-bar"></span>
+        <span class="ioi-static-header__toggle-bar"></span>
+        <span class="ioi-static-header__toggle-bar"></span>
+      </span>
+    </label>
+
+    <nav class="ioi-static-header__nav" aria-label="Primary navigation">
+      <ul class="ioi-static-header__nav-list">
+        <li class="ioi-static-header__nav-item ioi-static-header__nav-item--has-submenu">
+          <a class="ioi-static-header__nav-link" href="https://investinopen.org/our-approach/">
+            Our Approach <span class="ioi-static-header__caret" aria-hidden="true"></span>
+          </a>
+          <input id="ioi-static-header-approach-submenu" class="ioi-static-header__submenu-checkbox" type="checkbox" aria-label="Toggle Our Approach submenu">
+          <label class="ioi-static-header__submenu-toggle" for="ioi-static-header-approach-submenu" aria-label="Toggle Our Approach submenu"></label>
+          <ul class="ioi-static-header__submenu" aria-label="Our Approach submenu">
+            <li><a href="https://investinopen.org/our-approach/strategic-consulting/">Strategic Consulting</a></li>
+            <li><a href="https://investinopen.org/our-approach/coordinated-funding/">Coordinated Funding</a></li>
+          </ul>
         </li>
-        <li class="header-nav-item">
-          <span class="spacer">Get Involved</span>
-          <a href="https://investinopen.org/get-involved">Get Involved</a>
+        <li class="ioi-static-header__nav-item ioi-static-header__nav-item--has-submenu">
+          <a class="ioi-static-header__nav-link" href="https://investinopen.org/our-work/">
+            Our Work <span class="ioi-static-header__caret" aria-hidden="true"></span>
+          </a>
+          <input id="ioi-static-header-work-submenu" class="ioi-static-header__submenu-checkbox" type="checkbox" aria-label="Toggle Our Work submenu">
+          <label class="ioi-static-header__submenu-toggle" for="ioi-static-header-work-submenu" aria-label="Toggle Our Work submenu"></label>
+          <ul class="ioi-static-header__submenu" aria-label="Our Work submenu">
+            <li><%= nav_link "Infra Finder", solutions_path, active: :exclusive %></li>
+            <li><a href="https://investinopen.org/our-work/state-of-oi/">State of Open Infrastructure</a></li>
+          </ul>
+        </li>
+        <li class="ioi-static-header__nav-item">
+          <a class="ioi-static-header__nav-link" href="https://investinopen.org/blog/">News &amp; Updates</a>
+        </li>
+        <li class="ioi-static-header__nav-item ioi-static-header__nav-item--has-submenu">
+          <a class="ioi-static-header__nav-link" href="https://investinopen.org/about/">
+            About IOI <span class="ioi-static-header__caret" aria-hidden="true"></span>
+          </a>
+          <input id="ioi-static-header-about-submenu" class="ioi-static-header__submenu-checkbox" type="checkbox" aria-label="Toggle About IOI submenu">
+          <label class="ioi-static-header__submenu-toggle" for="ioi-static-header-about-submenu" aria-label="Toggle About IOI submenu"></label>
+          <ul class="ioi-static-header__submenu" aria-label="About IOI submenu">
+            <li><a href="https://investinopen.org/about/team/">Our Team</a></li>
+            <li><a href="https://investinopen.org/about/governance/">Our Governance</a></li>
+            <li><a href="https://investinopen.org/about/funding/">How We're Funded</a></li>
+            <li><a href="https://investinopen.org/about/strategic-plans/">Strategic Plan</a></li>
+            <li><a href="https://investinopen.org/about/our-impact/">Our Impact</a></li>
+          </ul>
         </li>
       </ul>
     </nav>
+
+    <div class="ioi-static-header__actions">
+      <a class="ioi-static-header__search" href="https://investinopen.org/#/search" aria-label="Search IOI">
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <circle cx="10.8" cy="10.8" r="6.4"></circle>
+          <path d="m16 16 5 5"></path>
+        </svg>
+      </a>
+      <a class="ioi-static-header__contact" href="https://investinopen.org/contact-us/">Get In Touch</a>
+    </div>
   </div>
 </header>
 <nav aria-labelledby="nav-infra-finder" class="m-nav-bar m-nav-bar--centered bg-brand-mint l-container">

--- a/app/components/header_component/header_component.html.erb
+++ b/app/components/header_component/header_component.html.erb
@@ -206,7 +206,7 @@
     padding: 0 1.45rem;
     border-radius: 999px;
     background: var(--ioi-yellow);
-    color: var(--ioi-black);
+    color: var(--ioi-black) !important;
     font-size: 1rem;
     font-weight: 800;
     line-height: 1;
@@ -535,7 +535,7 @@
         <%= nav_link t(".solutions_link"), solutions_path, active: :exclusive, class: "m-nav-bar__link", data: { text: t(".solutions_link") } %>
       </li>
       <li>
-        <a class="m-nav-bar__link" href="https://investinopen.org/data-room/about-infra-finder" data-text="<%= t(".about_link") %>">
+        <a class="m-nav-bar__link" href="https://investinopen.org/about-infra-finder/" data-text="<%= t(".about_link") %>">
           <%= t(".about_link") %>
         </a>
       </li>
@@ -550,7 +550,7 @@
         </a>
       </li>
       <li>
-        <a class="m-nav-bar__link" href="https://investinopen.org/data-room/about-infra-finder#support" data-text="<%= t(".support_link") %>">
+        <a class="m-nav-bar__link" href="https://investinopen.org/about-infra-finder/#support" data-text="<%= t(".support_link") %>">
           <%= t(".support_link") %>
         </a>
       </li>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       retries: 5
   redis:
     platform: "linux/amd64"
-    image: bitnami/redis:6.2.7-debian-10-r34
+    image: redis:6.2
     environment:
       - "ALLOW_EMPTY_PASSWORD=yes"
     logging:
@@ -36,7 +36,7 @@ services:
       retries: 5
   test-redis:
     platform: "linux/amd64"
-    image: bitnami/redis:6.2.7-debian-10-r34
+    image: redis:6.2
     environment:
       - "ALLOW_EMPTY_PASSWORD=yes"
     logging:


### PR DESCRIPTION
**What's changed:**

- header_component and footer_component templates replaced with the new static IOI header/footer. Styles are scoped/namespaced (ioi-static-*) and inlined in the templates, so no changes to existing stylesheets.
- Preserved Rails-specific behaviour: turbo frames, the Infra Finder sub-nav bar (incl. admin link), and the footer terms-of-use notice.
- Sub-nav "About Infra Finder" and "Support Infra Finder" now point to the new investinopen.org/about-infra-finder/ paths.

Also:
- docker-compose.yml: replaced bitnami/redis:6.2.7 with official redis:6.2 — Bitnami removed its legacy images from Docker Hub, so fresh clones couldn't build.

Tested locally (Docker): desktop + mobile nav, dropdowns, sub-nav, footer links.